### PR TITLE
simplify error check

### DIFF
--- a/conntrack.go
+++ b/conntrack.go
@@ -490,6 +490,18 @@ func putExtraHeader(familiy, version uint8, resid uint16) []byte {
 type extractFunc func([]byte) (Conn, error)
 
 func parseConnectionMsg(msg netlink.Message, reqType int) (Conn, error) {
+
+	if msg.Header.Type == netlink.Error {
+		errMsg, err := unmarschalErrMsg(msg.Data)
+		if err != nil {
+			return nil, err
+		}
+		if errMsg.Code == 0 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%#v", errMsg)
+	}
+
 	fnMap := map[int]extractFunc{
 		ipctnlMsgCtNew:         extractAttributes,
 		ipctnlMsgCtGet:         extractAttributes,

--- a/conntrack.go
+++ b/conntrack.go
@@ -361,10 +361,9 @@ func (nfct *Nfct) manageGroups(t CtTable, groups uint32, join bool) error {
 		return nil
 	}
 
-	if join == true {
+	manage = nfct.Con.LeaveGroup
+	if join {
 		manage = nfct.Con.JoinGroup
-	} else {
-		manage = nfct.Con.LeaveGroup
 	}
 
 	switch t {
@@ -491,17 +490,6 @@ func putExtraHeader(familiy, version uint8, resid uint16) []byte {
 type extractFunc func([]byte) (Conn, error)
 
 func parseConnectionMsg(msg netlink.Message, reqType int) (Conn, error) {
-	if msg.Header.Type&netlink.Error == netlink.Error {
-		errMsg, err := unmarschalErrMsg(msg.Data)
-		if err != nil {
-			return nil, err
-		}
-		if errMsg.Code == 0 {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("%#v", errMsg)
-	}
-
 	fnMap := map[int]extractFunc{
 		ipctnlMsgCtNew:         extractAttributes,
 		ipctnlMsgCtGet:         extractAttributes,
@@ -514,5 +502,5 @@ func parseConnectionMsg(msg netlink.Message, reqType int) (Conn, error) {
 		return fn(msg.Data)
 	}
 
-	return nil, fmt.Errorf("Unknown message type: 0x%02x", reqType)
+	return nil, fmt.Errorf("unknown message type: 0x%02x", reqType)
 }

--- a/conntrack_linux_integration_test.go
+++ b/conntrack_linux_integration_test.go
@@ -138,7 +138,7 @@ func TestLinuxConntrackDeleteEntry(t *testing.T) {
 	origSessID := []byte{}
 
 	for _, c := range conns {
-		if compare(c[AttrOrigIPv4Dst], []byte{127, 0, 0, 4}) == 0 {
+		if compare(c[AttrOrigIPv4Dst], []byte{127, 0, 0, 4}) == 0 && compare(c[AttrIcmpType], []byte{8}) == 0 {
 			sess := []ConnAttr{
 				{Type: AttrOrigIPv4Dst, Data: c[AttrOrigIPv4Dst]},
 				{Type: AttrOrigIPv4Src, Data: c[AttrOrigIPv4Src]},

--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package conntrack
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"net"
 	"time"
@@ -89,6 +90,10 @@ type ConnAttr struct {
 	Mask []byte
 	// Negates this attribute for filtering
 	Negate bool
+}
+
+func (ca ConnAttr) String() string {
+	return fmt.Sprintf("Type: %2d - Data: [%v] - Mask: [%v] - Negate: %t\n", ca.Type, ca.Data, ca.Mask, ca.Negate)
 }
 
 // ConnAttrType specifies the attribute of a connection
@@ -207,21 +212,21 @@ const (
 
 // Various errors which may occur when procressing a connection
 var (
-	ErrConnNoSrcIP = errors.New("Conn has no source IP")
-	ErrConnNoDstIP = errors.New("Conn has no destination IP")
-	ErrConnNoAttr  = errors.New("Conn has not this attribute")
+	ErrConnNoSrcIP = errors.New("conn has no source IP")
+	ErrConnNoDstIP = errors.New("conn has no destination IP")
+	ErrConnNoAttr  = errors.New("conn has not this attribute")
 )
 
 // Various errors which may occur when processing attributes
 var (
-	ErrAttrLength         = errors.New("Incorrect length of attribute")
-	ErrAttrNotImplemented = errors.New("Attribute not implemented")
-	ErrAttrNotExist       = errors.New("Type of attribute does not exist")
-	ErrDataLength         = errors.New("Incorrect length of provided data")
+	ErrAttrLength         = errors.New("incorrect length of attribute")
+	ErrAttrNotImplemented = errors.New("attribute not implemented")
+	ErrAttrNotExist       = errors.New("type of attribute does not exist")
+	ErrDataLength         = errors.New("incorrect length of provided data")
 )
 
 // ErrUnknownCtTable will be return, if the function can not be performed on this subsystem
-var ErrUnknownCtTable = errors.New("Not supported for this subsystem")
+var ErrUnknownCtTable = errors.New("not supported for this subsystem")
 
 // OrigSrcIP returns the net.IP representation of the source IP
 func (c Conn) OrigSrcIP() (net.IP, error) {


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

Investigations for https://github.com/florianl/go-conntrack/issues/6 showed, that error message handling in `parseConnectionMsg()` is not needed, as it is already done by the underlying netlink library.