### PR TITLE
fix: encode 16 bits value error

### DIFF
--- a/bpf.go
+++ b/bpf.go
@@ -138,7 +138,7 @@ func encodeValue(data []byte) (val uint32) {
 	case 1:
 		val = uint32(data[0])
 	case 2:
-		val = binary.BigEndian.Uint32(data)
+		val = uint32(binary.BigEndian.Uint16(data))
 	case 4:
 		val = binary.BigEndian.Uint32(data)
 	}


### PR DESCRIPTION
use binary.BigEndian.Uint32 with a byte array whose length is 2 resulting following panic:
"panic: runtime error: index out of range [3] with length 2"

Signed-off-by: Xia Yinchang <xiayinchang@gmail.com>