### PR TITLE
Decode TCPFlags struct

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -276,11 +276,25 @@ func extractTCPInfo(v *TCPInfo, logger *log.Logger, data []byte) error {
 			tmp := ad.Uint8()
 			v.WScaleRepl = &tmp
 		case ctaProtoinfoTCPFlagsOrig:
+			flags := &TCPFlags{}
 			tmp := ad.Bytes()
-			v.FlagsOrig = &tmp
+			if len(tmp) > 0 {
+				flags.Flags = &tmp[0]
+			}
+			if len(tmp) > 1 {
+				flags.Mask = &tmp[1]
+			}
+			v.FlagsOrig = flags
 		case ctaProtoinfoTCPFlagsRepl:
+			flags := &TCPFlags{}
 			tmp := ad.Bytes()
-			v.FlagsReply = &tmp
+			if len(tmp) > 0 {
+				flags.Flags = &tmp[0]
+			}
+			if len(tmp) > 1 {
+				flags.Mask = &tmp[1]
+			}
+			v.FlagsReply = flags
 		default:
 			logger.Printf("extractTCPInfo(): %d | %d\t %v", ad.Type(), ad.Type()&0xFF, ad.Bytes())
 		}
@@ -307,10 +321,24 @@ func marshalTCPInfo(logger *log.Logger, v *TCPInfo) ([]byte, error) {
 		ae.ByteOrder = nativeEndian
 	}
 	if v.FlagsOrig != nil {
-		ae.Bytes(ctaProtoinfoTCPFlagsOrig, *v.FlagsOrig)
+		tmp := []byte{0x00, 0xff}
+		if v.FlagsOrig.Flags != nil {
+			tmp[0] = *v.FlagsOrig.Flags
+		}
+		if v.FlagsOrig.Mask != nil {
+			tmp[1] = *v.FlagsOrig.Mask
+		}
+		ae.Bytes(ctaProtoinfoTCPFlagsOrig, tmp)
 	}
 	if v.FlagsReply != nil {
-		ae.Bytes(ctaProtoinfoTCPFlagsRepl, *v.FlagsReply)
+		tmp := []byte{0x00, 0xff}
+		if v.FlagsReply.Flags != nil {
+			tmp[0] = *v.FlagsReply.Flags
+		}
+		if v.FlagsReply.Mask != nil {
+			tmp[1] = *v.FlagsReply.Mask
+		}
+		ae.Bytes(ctaProtoinfoTCPFlagsRepl, tmp)
 	}
 
 	return ae.Encode()

--- a/types.go
+++ b/types.go
@@ -91,13 +91,19 @@ type Timestamp struct {
 	Stop  *time.Time
 }
 
+// TCPFlags contains additional information for TCP flags
+type TCPFlags struct {
+	Flags *uint8
+	Mask  *uint8
+}
+
 // TCPInfo contains additional information for TCP sessions
 type TCPInfo struct {
 	State      *uint8
 	WScaleOrig *uint8
 	WScaleRepl *uint8
-	FlagsOrig  *[]byte
-	FlagsReply *[]byte
+	FlagsOrig  *TCPFlags
+	FlagsReply *TCPFlags
 }
 
 // DCCPInfo contains additional information for DCCP sessions


### PR DESCRIPTION
TCP flags are passed into netlink as a struct consisting of two fields: flags and mask.
This change exposes the fields of this struct in the types API.

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/netfilter/nf_conntrack_tcp.h?h=v5.9#n52