### PR TITLE
Add the table and the group to the hook function

### DIFF
--- a/conntrack.go
+++ b/conntrack.go
@@ -382,16 +382,7 @@ func (nfct *Nfct) register(ctx context.Context, t Table, groups NetlinkGroup, fi
 					continue
 				}
 				// Attempt to detect the table of the received event
-				var nlTable Table
-				msgTypeTable := (msg.Header.Type&0x300)>>8
-				switch msgTypeTable {
-				case unix.NFNL_SUBSYS_CTNETLINK:
-					nlTable = Conntrack
-				case unix.NFNL_SUBSYS_CTNETLINK_EXP:
-					nlTable = Expected
-				default:
-					nfct.logger.Printf("Unable to detect the table of the received message. Unknown table: %v", msgTypeTable)
-				}
+				msgTypeTable := Table((msg.Header.Type&0x300)>>8)
 				// Attempt to detect the group of the received event
 				var nlGroup NetlinkGroup
 				msgTypeGroup := (msg.Header.Type&0xF)


### PR DESCRIPTION
In the current situation, it is not possible to subscribe to multiple groups and to know what event had occurred.

This PR adds the table and the group the hook function, solving this limitation.
Such code, is now possible:
```
HookFunc := func(c ct.Con, table ct.Table, group ct.NetlinkGroup) int {
	switch group {
		case ct.NetlinkCtNew:
			// do something
		case ct.NetlinkCtUpdate:
			// do something
		case ct.NetlinkCtDestroy:
			// do something
	}
}
nfct.Register(context.Background(), ct.Conntrack, ct.NetlinkCtNew|ct.NetlinkCtUpdate|ct.NetlinkCtDestroy, HookFunc)
```
		