### PR TITLE
Fix determination of the event type

### DIFF
--- a/conntrack.go
+++ b/conntrack.go
@@ -368,9 +368,21 @@ func (nfct *Nfct) register(ctx context.Context, t Table, groups NetlinkGroup, fi
 	enricher := func(*Con, netlink.Header) {}
 	if nfct.addConntrackInformation {
 		enricher = func(c *Con, h netlink.Header) {
+			var group NetlinkGroup
+
+			if h.Type&0xFF == ipctnlMsgCtNew {
+				if h.Flags&(netlink.Create|netlink.Excl) != 0 {
+					group = NetlinkCtNew
+				} else {
+					group = NetlinkCtUpdate
+				}
+			} else {
+				group = NetlinkCtDestroy
+			}
+
 			info := InfoSource{
 				Table:        Table((h.Type & 0x300) >> 8),
-				NetlinkGroup: NetlinkGroup(h.Type & 0xF),
+				NetlinkGroup: group,
 			}
 			c.Info = &info
 		}


### PR DESCRIPTION
h.Type doesn't map directly to the nelink group. Add some code to correctly determine the event type.

This code is equivalent to the code from libnetfilter_conntrack C lib:
```
	switch(nlh->nlmsg_type & 0xFF) {
	case IPCTNL_MSG_CT_NEW:
		if (nlh->nlmsg_flags & (NLM_F_CREATE|NLM_F_EXCL))
			type = NFCT_T_NEW;
		else
			type = NFCT_T_UPDATE;
		break;
	case IPCTNL_MSG_CT_DELETE:
		type = NFCT_T_DESTROY;
		break;
	}
```

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>