### PR TITLE
mark filter fix

### DIFF
--- a/bpf.go
+++ b/bpf.go
@@ -4,11 +4,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"sort"
-	"strings"
-
 	"github.com/florianl/go-conntrack/internal/unix"
 	"golang.org/x/net/bpf"
+	"sort"
 )
 
 // Various errors which may occur when processing filters
@@ -393,7 +391,9 @@ func (nfct *Nfct) attachFilter(subsys Table, filters []ConnAttr) error {
 	}
 	if nfct.debug {
 		fmtInstructions := fmtRawInstructions(bpfFilters)
-		fmt.Print(strings.Join(fmtInstructions, ""))
+		fmt.Println("---BPF filter start---")
+		fmt.Print(fmtInstructions)
+		fmt.Println("---BPF filter end---")
 	}
 
 	return nfct.Con.SetBPF(bpfFilters)
@@ -413,11 +413,11 @@ func fmtRawInstruction(index int, raw bpf.RawInstruction) string {
 		raw.K&0xFFFFFFFF)
 }
 
-func fmtRawInstructions(raw []bpf.RawInstruction) []string {
-	output := make([]string, len(raw))
+func fmtRawInstructions(raw []bpf.RawInstruction) string {
+	var output string
 
 	for i, instr := range raw {
-		output[i] = fmtRawInstruction(i, instr)
+		output += fmtRawInstruction(i, instr)
 	}
 
 	return output

--- a/bpf.go
+++ b/bpf.go
@@ -391,9 +391,9 @@ func (nfct *Nfct) attachFilter(subsys Table, filters []ConnAttr) error {
 	}
 	if nfct.debug {
 		fmtInstructions := fmtRawInstructions(bpfFilters)
-		fmt.Println("---BPF filter start---")
-		fmt.Print(fmtInstructions)
-		fmt.Println("---BPF filter end---")
+		nfct.logger.Println("---BPF filter start---")
+		nfct.logger.Print(fmtInstructions)
+		nfct.logger.Println("---BPF filter end---")
 	}
 
 	return nfct.Con.SetBPF(bpfFilters)

--- a/bpf_test.go
+++ b/bpf_test.go
@@ -2,8 +2,8 @@ package conntrack
 
 import (
 	"encoding/binary"
+	"errors"
 	"github.com/florianl/go-conntrack/internal/unix"
-	"strings"
 	"testing"
 
 	"golang.org/x/net/bpf"
@@ -280,11 +280,11 @@ func TestAttrMarkFilter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			rawInstr, err := constructFilter(tc.table, tc.filters)
-			if err != tc.err {
+			if !errors.Is(err, tc.err) {
 				t.Fatal(err)
 			}
 			if len(rawInstr) != len(tc.rawInstr) {
-				t.Fatalf("different length:\n- want:\n%s\n-  got:\n%s", strings.Join(fmtRawInstructions(tc.rawInstr), ""), strings.Join(fmtRawInstructions(rawInstr), ""))
+				t.Fatalf("different length:\n- want:\n%s\n-  got:\n%s", fmtRawInstructions(tc.rawInstr), fmtRawInstructions(rawInstr))
 			}
 			var isErr bool
 			for i, v := range rawInstr {
@@ -295,7 +295,7 @@ func TestAttrMarkFilter(t *testing.T) {
 			}
 
 			if isErr {
-				t.Fatalf("unexpected reply:\n- want:\n%s\n-  got:\n%s", strings.Join(fmtRawInstructions(tc.rawInstr), ""), strings.Join(fmtRawInstructions(rawInstr), ""))
+				t.Fatalf("unexpected reply:\n- want:\n%s\n-  got:\n%s", fmtRawInstructions(tc.rawInstr), fmtRawInstructions(rawInstr))
 			}
 		})
 	}

--- a/bpf_test.go
+++ b/bpf_test.go
@@ -1,6 +1,9 @@
 package conntrack
 
 import (
+	"encoding/binary"
+	"github.com/florianl/go-conntrack/internal/unix"
+	"strings"
 	"testing"
 
 	"golang.org/x/net/bpf"
@@ -167,6 +170,133 @@ func TestConstructFilter(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+func TestAttrMarkFilter(t *testing.T) {
+	mark1ByteValue := make([]byte, 4)
+	binary.BigEndian.PutUint32(mark1ByteValue, 1)
+	mark10ByteValue := make([]byte, 4)
+	binary.BigEndian.PutUint32(mark10ByteValue, 10)
+	mark11ByteValue := make([]byte, 4)
+	binary.BigEndian.PutUint32(mark11ByteValue, 11)
+	mark50ByteValue := make([]byte, 4)
+	binary.BigEndian.PutUint32(mark50ByteValue, 50)
+	mark1000ByteValue := make([]byte, 4)
+	binary.BigEndian.PutUint32(mark1000ByteValue, 1000)
+
+	tests := []struct {
+		name     string
+		table    Table
+		filters  []ConnAttr
+		rawInstr []bpf.RawInstruction
+		err      error
+	}{
+		{name: "mark positive filter: [1]", table: Conntrack, filters: []ConnAttr{
+			{Type: AttrMark, Data: mark1ByteValue, Mask: []byte{255, 255, 255, 255}, Negate: false},
+		}, rawInstr: []bpf.RawInstruction{
+			//--- check subsys ---
+			{Op: unix.BPF_LDX | unix.BPF_IMM, Jt: 0x00, Jf: 0x00, K: 0x00000004},
+			{Op: unix.BPF_LD | unix.BPF_B | unix.BPF_IND, Jt: 0x00, Jf: 0x00, K: 0x00000001},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x01, Jf: 0x00, K: 0x00000001},
+			{Op: unix.BPF_RET | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+			//--- check mark ---
+			{Op: unix.BPF_LD | unix.BPF_IMM, Jt: 0x00, Jf: 0x00, K: 0x00000014},
+			{Op: unix.BPF_LDX | unix.BPF_IMM, Jt: 0x00, Jf: 0x00, K: 0x00000008},
+			{Op: unix.BPF_LD | unix.BPF_B | unix.BPF_ABS, Jt: 0x00, Jf: 0x00, K: 0xfffff00c},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x02, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_MISC | unix.BPF_TAX, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_LD | unix.BPF_W | unix.BPF_IND, Jt: 0x00, Jf: 0x00, K: 0x00000004},
+			{Op: unix.BPF_MISC | unix.BPF_TAX, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_ALU | unix.BPF_AND | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x02, Jf: 0x00, K: 0x00000001},
+			{Op: unix.BPF_MISC | unix.BPF_TXA, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_RET | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			//---- final verdict ----
+			{Op: unix.BPF_RET | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+		}},
+		{name: "mark positive filter: [10,50,1000]", table: Conntrack, filters: []ConnAttr{
+			{Type: AttrMark, Data: mark10ByteValue, Mask: []byte{255, 255, 255, 255}, Negate: false},
+			{Type: AttrMark, Data: mark50ByteValue, Mask: []byte{255, 255, 255, 255}, Negate: false},
+			{Type: AttrMark, Data: mark1000ByteValue, Mask: []byte{255, 255, 255, 255}, Negate: false},
+		}, rawInstr: []bpf.RawInstruction{
+			//--- check subsys ---
+			{Op: unix.BPF_LDX | unix.BPF_IMM, Jt: 0x00, Jf: 0x00, K: 0x00000004},
+			{Op: unix.BPF_LD | unix.BPF_B | unix.BPF_IND, Jt: 0x00, Jf: 0x00, K: 0x00000001},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x01, Jf: 0x00, K: 0x00000001},
+			{Op: unix.BPF_RET | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+			//--- check mark ---
+			{Op: unix.BPF_LD | unix.BPF_IMM, Jt: 0x00, Jf: 0x00, K: 0x00000014},
+			{Op: unix.BPF_LDX | unix.BPF_IMM, Jt: 0x00, Jf: 0x00, K: 0x00000008},
+			{Op: unix.BPF_LD | unix.BPF_B | unix.BPF_ABS, Jt: 0x00, Jf: 0x00, K: 0xfffff00c},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x02, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_MISC | unix.BPF_TAX, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_LD | unix.BPF_W | unix.BPF_IND, Jt: 0x00, Jf: 0x00, K: 0x00000004},
+			{Op: unix.BPF_MISC | unix.BPF_TAX, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_ALU | unix.BPF_AND | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x08, Jf: 0x00, K: 0x0000000a},
+			{Op: unix.BPF_MISC | unix.BPF_TXA, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_ALU | unix.BPF_AND | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x05, Jf: 0x00, K: 0x00000032},
+			{Op: unix.BPF_MISC | unix.BPF_TXA, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_ALU | unix.BPF_AND | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x02, Jf: 0x00, K: 0x000003e8},
+			{Op: unix.BPF_MISC | unix.BPF_TXA, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_RET | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			//---- final verdict ----
+			{Op: unix.BPF_RET | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+		}},
+		{name: "mark negative filter: [10,11]", table: Conntrack, filters: []ConnAttr{
+			{Type: AttrMark, Data: mark10ByteValue, Mask: []byte{255, 255, 255, 255}, Negate: true},
+			{Type: AttrMark, Data: mark11ByteValue, Mask: []byte{255, 255, 255, 255}, Negate: true},
+		}, rawInstr: []bpf.RawInstruction{
+			//--- check subsys ---
+			{Op: unix.BPF_LDX | unix.BPF_IMM, Jt: 0x00, Jf: 0x00, K: 0x00000004},
+			{Op: unix.BPF_LD | unix.BPF_B | unix.BPF_IND, Jt: 0x00, Jf: 0x00, K: 0x00000001},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x01, Jf: 0x00, K: 0x00000001},
+			{Op: unix.BPF_RET | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+			//--- check mark ---
+			{Op: unix.BPF_LD | unix.BPF_IMM, Jt: 0x00, Jf: 0x00, K: 0x00000014},
+			{Op: unix.BPF_LDX | unix.BPF_IMM, Jt: 0x00, Jf: 0x00, K: 0x00000008},
+			{Op: unix.BPF_LD | unix.BPF_B | unix.BPF_ABS, Jt: 0x00, Jf: 0x00, K: 0xfffff00c},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x02, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_MISC | unix.BPF_TAX, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_LD | unix.BPF_W | unix.BPF_IND, Jt: 0x00, Jf: 0x00, K: 0x00000004},
+			{Op: unix.BPF_MISC | unix.BPF_TAX, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_ALU | unix.BPF_AND | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x05, Jf: 0x00, K: 0x0000000a},
+			{Op: unix.BPF_MISC | unix.BPF_TXA, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_ALU | unix.BPF_AND | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+			{Op: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 0x02, Jf: 0x00, K: 0x0000000b},
+			{Op: unix.BPF_MISC | unix.BPF_TXA, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			{Op: unix.BPF_JMP | unix.BPF_JA, Jt: 0x00, Jf: 0x00, K: 0x00000001},
+			{Op: unix.BPF_RET | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0x00000000},
+			//---- final verdict ----
+			{Op: unix.BPF_RET | unix.BPF_K, Jt: 0x00, Jf: 0x00, K: 0xffffffff},
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rawInstr, err := constructFilter(tc.table, tc.filters)
+			if err != tc.err {
+				t.Fatal(err)
+			}
+			if len(rawInstr) != len(tc.rawInstr) {
+				t.Fatalf("different length:\n- want:\n%s\n-  got:\n%s", strings.Join(fmtRawInstructions(tc.rawInstr), ""), strings.Join(fmtRawInstructions(rawInstr), ""))
+			}
+			var isErr bool
+			for i, v := range rawInstr {
+				if v != tc.rawInstr[i] {
+					t.Errorf("unexpected instruction:\n- want:\n%s\n-  got:\n%s", fmtRawInstruction(i, tc.rawInstr[i]), fmtRawInstruction(i, rawInstr[i]))
+					isErr = true
+				}
+			}
+
+			if isErr {
+				t.Fatalf("unexpected reply:\n- want:\n%s\n-  got:\n%s", strings.Join(fmtRawInstructions(tc.rawInstr), ""), strings.Join(fmtRawInstructions(rawInstr), ""))
+			}
 		})
 	}
 }

--- a/conntrack.go
+++ b/conntrack.go
@@ -367,6 +367,11 @@ func (nfct *Nfct) RegisterFiltered(ctx context.Context, t Table, group NetlinkGr
 	return nfct.register(ctx, t, group, filter, fn)
 }
 
+// EnableDebug print bpf filter for RegisterFiltered function
+func (nfct *Nfct) EnableDebug() {
+	nfct.debug = true
+}
+
 func (nfct *Nfct) register(ctx context.Context, t Table, groups NetlinkGroup, filter []ConnAttr, fn func(c Con) int) error {
 	nfct.ctx, nfct.ctxCancel = context.WithCancel(ctx)
 	nfct.shutdown = make(chan struct{})

--- a/types.go
+++ b/types.go
@@ -75,6 +75,8 @@ type Nfct struct {
 
 	errChan chan error
 
+	debug bool
+
 	setWriteTimeout func() error
 
 	ctx       context.Context


### PR DESCRIPTION
Hi @florianl,
I tried to use Mark filter for my application, but I found out that current implementation doesn't work.
So I checked the original source and found out that mark filter creation is little bit different than for example ipfilter:
https://git.netfilter.org/libnetfilter_conntrack/tree/src/conntrack/bsf.c#n685

Here is a comparison of filter generated by original library and this go package (example with mark set to 11):
![Screenshot 2023-10-17 at 16 53 23](https://github.com/florianl/go-conntrack/assets/15923956/7d1c4aaa-6091-46d9-8f86-3d70b705ed66)

I implemented the filter according to original version. As this filter contains different instructions and flow of instructions, I decided to put it into different function.

I'm testing it and it seems to be working fine. Please let me know what do you think about it. If you say it's ok, I will add tests which will cover this filter.

Regards,
Martin
